### PR TITLE
removed specified dates from stat insight

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,6 +147,22 @@ def get_flights(columns=["id", "flight_date", "flight_time_utc"], table="flights
     
     return flight_data
 
+def get_flights_stats(columns=["id", "flight_date", "flight_time_utc"], table="flights"):
+    """
+    The function uses the query_flights class to get all the flights ids and dates in a dictionary of key: value --> flight_date: flight_id. 
+
+    Parameters:
+        date: Boolean value to specify if you only want to return a list of flight dates from the DB.
+
+    Returns:
+        if date is FALSE --> flight_date: dictionary of flight_date: flight_id pairs
+    """
+    flights = query_flights()
+
+    flight_data = flights.get_flight_id_and_dates_stats(columns, table)
+    
+    return flight_data
+
 # Function ---------------------------------------------------------------------------------------------------------------------------------------------------------
 def get_most_recent_run_time():
     new_date = flights.get_last_scraper_runtime().strftime("%b %d, %Y at %I:%M %p")
@@ -542,7 +558,7 @@ app_ui = ui.page_fluid(
                     ui.p("Discover valuable insights into the heart of the e-plane — the battery. Explore how different aircraft maneuvers affect the battery’s state of charge through detailed statistical visualizations. Additionally, monitor the battery's health over time, enabling you to derive actionable insights and enhance your decision-making processes."), min_height="130px"
                 ), 
                 div(HTML("<hr>")),
-                ui.input_selectize("statistical_time", "Choose Flight Date:", get_flights()),
+                ui.input_selectize("statistical_time", "Choose Flight Date:", get_flights_stats()),
                 ui.p("          "),
                 ui.row(
                     ui.column(6,

--- a/app.py
+++ b/app.py
@@ -430,7 +430,7 @@ app_ui = ui.page_fluid(
                 div(HTML("<hr>")),
                 div(HTML("<h4> Flight Graphs </h4>")),
                 ui.layout_columns(
-                    ui.input_selectize("singular_flight_date", "Choose Flight Date:", get_flights()),
+                    ui.input_selectize("singular_flight_date", "Choose Flight Date:", get_flights_stats()),
                     col_widths=(3)
                 ),
                 ui.p("          "),
@@ -460,7 +460,7 @@ app_ui = ui.page_fluid(
                 div(HTML("<hr>")),
                 div(HTML("<h4> Time Graphs </h4>")),
                 ui.layout_columns(
-                    ui.input_selectize("multi_select_flight_dates", "Choose Flight Date(s):", get_flights(), multiple=True),
+                    ui.input_selectize("multi_select_flight_dates", "Choose Flight Date(s):", get_flights_stats(), multiple=True),
                     col_widths=(3)
                 ),
                 ui.p("          "),

--- a/flight_querying.py
+++ b/flight_querying.py
@@ -94,6 +94,30 @@ class query_flights:
 
         return flights
     
+    # Get Flights Function Stats-----------------------------------------------------------------------------------------------------------------
+    def get_flights_stats(self, columns: list, table):
+        """
+        The function runs the following query: SELECT {columns} FROM {table} WHERE flight_type NOT IN ('Charging', 'Ground test') . This gets all the flight id's and dates of the flight.
+        """
+
+        # Make query
+        if len(columns) == 0:
+            query = f"SELECT * FROM {table}"
+        else:
+            str_column = "".join([f"{column}, " for column in columns])[:-2]
+            query = f"SELECT {str_column} FROM {table} WHERE flight_type IN ('Flight test')"
+
+        # Make database connection
+        engine = self.__connect()
+
+        # Select the data based on the query
+        flights = pd.read_sql_query(query, engine)
+
+        # Dispose of the connection, so we don't overuse it.
+        engine.dispose()
+
+        return flights
+    
     # get all Flight IDs ------------------------------------------------------------------------------------------------------------
     def get_flight_ids(self):
         """
@@ -305,6 +329,40 @@ class query_flights:
             flight_dict[id] = date
 
         return flight_dict
+
+    # Get Flight Id and Dates Function for Stats Graph (exclude ground test and charge data)---------------------------------------------------------------------------------------------------
+    def get_flight_id_and_dates_stats(self, columns, table):
+        """
+        Function gets all flight ids and dates and returns a dictionary of flight_id : flight_date 
+        """
+
+        # Initialize the dictionary
+        flight_dict = {}
+
+        # Get all the flights
+        flights_df = self.get_flights_stats(columns, table)
+
+        # Change to Numpy
+        ids = flights_df[columns[0]].to_numpy()
+        flight_dates = flights_df[columns[1]].to_numpy()
+
+        if len(columns) > 2:
+            flight_times = flights_df[columns[2]].to_numpy()
+            datetimes = [datetime.combine(flight_dates[i], flight_times[i]) - relativedelta(hours=5) for i in range(len(flight_dates))]
+
+        # Loop over all the flight dates to input into dictionary
+        for i in range(len(flight_dates)):
+            
+            # Create a string object to show the date in mm/dd/year format. Create Key: Value relation.
+            if len(columns) > 2:
+                date = datetimes[i].strftime("%b %d, %Y at %I:%M %p")
+            else:
+                date = flight_dates[i].strftime("%B %d, %Y")
+
+            id = str(ids[i])
+            flight_dict[id] = date
+
+        return flight_dict    
     
 
     # Get Flight Id, SOC, and Time (in minutes) Function --------------------------------------------------------------------------------


### PR DESCRIPTION
## Checklist
- [x] Did I add this pull request into the appropriate Notion ticket? If not, create a ticket for this PR.
**Note:** Put an x into the box like this [x] to check these off

## What I Did
What files git you edit and why/for what purpose?
- flight_querying.py - added new query that does only flight_type = 'Flight test' 
(I tried to do where flight_type is not 'Charging' and 'Ground test' but it doesn't work since flights which are 'Flight test and charging' still give the error, so I filtered by flight_type = 'Flight test') 
- app.py to call the new querying function

## How I Did it?
What packages did I install to accomplish this goal? What libraries did I need that the team might not know?
Write anything in this section that is technically related that everyone on the team might not know or is not
trivial.

## How to Test?
Manual testing? Automated testing? E2E testing? Smoke tests?
- Check neon DB for which dates are charging and ground test, and verify they are not on the stat insight UI anymore 

### Relevant Links
Any tutorials or other resources used to help with this task. You can also cite the documentation.
