### PR TITLE
Scraper runtime is now standardized to EST

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -18,6 +18,7 @@ from transformation import transform_overview_data, weather_transformation
 from storage import table_exists, view_exists, db_connect, execute, select, push_flight_metadata, push_flight_data, push_scraper_runtime, relevant_weather
 import queries
 import platform
+import pytz
 
 # Path variables
 chromedriver_path = "./dependencies/chromedriver-win64/chromedriver.exe"
@@ -27,6 +28,14 @@ def log_last_run_time():
     if not table_exists('scraper_last_run', conn):
       execute(queries.SCRAPER_RUNTIME)
     current_time = dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    # Check the system timezone
+    system_timezone = dt.datetime.now(dt.timezone.utc).astimezone().tzinfo
+    if system_timezone != pytz.timezone('America/New_York'):
+        # Convert time to Eastern Time
+        wrong_tz = dt.datetime.now()
+        est_tz = pytz.timezone('America/New_York')
+        est_time = wrong_tz.astimezone(est_tz)
+        current_time = est_time.strftime('%Y-%m-%d %H:%M:%S')
     # insert the current time into table
     push_scraper_runtime(current_time)
 


### PR DESCRIPTION
## Checklist
- [x] Did I add this pull request into the appropriate Notion ticket? If not, create a ticket for this PR.

## What I Did
What files git you edit and why/for what purpose?

**scraper.py**: the scraper is now timezone agnostic. In whichever timezone it is run, it will convert to eastern time, which is then pushed to the database and therefore displayed in the app.

## How to Test?

1. Change your computer timezone to anything other than eastern time
2. Run scraper locally
3. Check the neon db or the shiny app to verify the time was converted to eastern time.
